### PR TITLE
feat: add sitemap links and robots.txt

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://chihyang.blog/sitemap-index.xml

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -17,6 +17,7 @@ const { title, description } = Astro.props;
 <html lang="en">
   <head>
     <Head title={`${title} | ${SITE.TITLE}`} description={description} />
+    <link rel="sitemap" href="/sitemap-index.xml" />
   </head>
   <body>
     <Header />


### PR DESCRIPTION
This pull request introduces changes to improve the discoverability of the website by search engines. The updates include adding a `robots.txt` file and a sitemap link in the HTML head.

### SEO Improvements:

* [`public/robots.txt`](diffhunk://#diff-1dc4bea7b6827b18f8869436bd7786266d3cea8596529887ef16a027eb2e4076R1-R4): Added a `robots.txt` file to allow all user agents to crawl the site and provided a link to the sitemap (`https://chihyang.blog/sitemap-index.xml`).
* [`src/layouts/Layout.astro`](diffhunk://#diff-ba00f1d7bc63648f0861e03d786d6f1ed78307f1b40284e4db329586d3df2db2R20): Added a `<link>` element in the HTML head to reference the sitemap (`/sitemap-index.xml`) for better search engine indexing.